### PR TITLE
Fix Loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@ var flowRemoveTypes = require('flow-remove-types');
 
 module.exports = function(source) {
   this.cacheable();
-  return flowRemoveTypes(source);
+  return flowRemoveTypes(source).toString();
 }


### PR DESCRIPTION
The current version doesn't work, because flowRemoveTypes returns an object with a `toString()` method.