### PR TITLE
Pass options to flow-remove-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Remove Flow Types Webpack Loader
 This plugin will remove [Flow](https://flowtype.org) type annotations during
 bundling using [`flow-remove-types`](https://github.com/leebyron/flow-remove-types).
 
+Options passed to this loader are passed through to flow-remove-types.
 ## Install
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
-var flowRemoveTypes = require('flow-remove-types');
+const flowRemoveTypes = require('flow-remove-types');
+const loaderUtils = require('loader-utils');
 
-module.exports = function(source) {
+module.exports = function (source) {
   this.cacheable();
-  return flowRemoveTypes(source).toString();
-}
+
+  const options = Object.assign({}, loaderUtils.getOptions(this));
+
+  return flowRemoveTypes(source, options).toString();
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Conor Hastings",
   "license": "MIT",
   "dependencies": {
-    "flow-remove-types": "^1.0.0"
+    "flow-remove-types": "^1.0.0",
+    "loader-utils": "^1.1.0"
   }
 }


### PR DESCRIPTION
Uses [loader-utils](https://github.com/webpack/loader-utils) to grab the options from the loader config and sends them to flow-remove-types.